### PR TITLE
Safe mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript": "4.9.4"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "publishConfig": {
     "access": "public"

--- a/src/es-tests/set-not-flattened.es.test.ts
+++ b/src/es-tests/set-not-flattened.es.test.ts
@@ -76,7 +76,7 @@ describe('#setNotFlattened', () => {
         hasOscar: false,
         extra: {
           rating: 9.5,
-          actors: ["Sam Worthington", "Zoe Saldaña"]
+          actors: ['Sam Worthington', 'Zoe Saldaña'],
         },
       },
     };
@@ -101,7 +101,7 @@ describe('#setNotFlattened', () => {
       meta: {
         extra: {
           rating: 9.5,
-          actors: ["Sam Worthington", "Zoe Saldaña"]
+          actors: ['Sam Worthington', 'Zoe Saldaña'],
         },
         hasOscar: false,
         year: 2022,

--- a/src/es-tests/set-not-flattened.es.test.ts
+++ b/src/es-tests/set-not-flattened.es.test.ts
@@ -61,4 +61,52 @@ describe('#setNotFlattened', () => {
       name: 'titanic',
     });
   });
+
+  it('use set not flattended with safe mode', async () => {
+    await client.create({
+      index: 'files-alias',
+      id: 'some-file-61',
+      body: {name: 'Avatar 2'},
+      refresh: true,
+    });
+
+    const fieldsMap = {
+      meta: {
+        year: 2022,
+        hasOscar: false,
+        extra: {
+          rating: 9.5,
+          actors: ["Sam Worthington", "Zoe Saldaña"]
+        },
+      },
+    };
+
+    const painlessScript = painlessFields.setNotFlattened(fieldsMap, true);
+
+    await client.update({
+      index: 'files-alias',
+      id: 'some-file-61',
+      body: {
+        script: painlessScript,
+      },
+      refresh: true,
+    });
+
+    const updatedDoc = await client.get({
+      index: 'files-alias',
+      id: 'some-file-61',
+    });
+
+    expect(updatedDoc._source).toEqual({
+      meta: {
+        extra: {
+          rating: 9.5,
+          actors: ["Sam Worthington", "Zoe Saldaña"]
+        },
+        hasOscar: false,
+        year: 2022,
+      },
+      name: 'Avatar 2',
+    });
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,8 +55,8 @@ describe('#set', () => {
   it('should work with hyphens', () => {
     const fieldsMap = {};
 
-    fieldsMap["first-name"] = "John";
-    fieldsMap["last-name"] = "Doe";
+    fieldsMap['first-name'] = 'John';
+    fieldsMap['last-name'] = 'Doe';
 
     const result = m.setNotFlattened(fieldsMap);
 
@@ -64,19 +64,19 @@ describe('#set', () => {
       lang: 'painless',
       source: `ctx._source['first-name'] = params['first-name']; ctx._source['last-name'] = params['last-name'];`,
       params: {
-        'first-name': "John",
-        'last-name': "Doe",
+        'first-name': 'John',
+        'last-name': 'Doe',
       },
     });
   });
 
   it('should assert subobjects with safe mode', () => {
     const fieldsMap = {
-      'first-name': "John",
-      'last-name': "Doe",
+      'first-name': 'John',
+      'last-name': 'Doe',
       metadata: {
-        paying: true
-      }
+        paying: true,
+      },
     };
 
     const result = m.setNotFlattened(fieldsMap, true);
@@ -85,11 +85,11 @@ describe('#set', () => {
       lang: 'painless',
       source: `if (ctx._source['metadata'] == null) { ctx._source['metadata'] = [:] }ctx._source['first-name'] = params['first-name']; ctx._source['last-name'] = params['last-name']; ctx._source['metadata']['paying'] = params['metadata']['paying'];`,
       params: {
-        'first-name': "John",
-        'last-name': "Doe",
+        'first-name': 'John',
+        'last-name': 'Doe',
         metadata: {
           paying: true,
-        }
+        },
       },
     });
   });
@@ -136,8 +136,7 @@ describe('#setNotFlattened', () => {
         },
         name: 'titanic',
       },
-      source:
-        `ctx._source['id'] = params['id']; ctx._source['name'] = params['name']; ctx._source['meta']['year'] = params['meta']['year']; ctx._source['meta']['hasOscar'] = params['meta']['hasOscar']; ctx._source['meta']['actors'] = params['meta']['actors']; ctx._source['meta']['extra']['rating'] = params['meta']['extra']['rating'];`,
+      source: `ctx._source['id'] = params['id']; ctx._source['name'] = params['name']; ctx._source['meta']['year'] = params['meta']['year']; ctx._source['meta']['hasOscar'] = params['meta']['hasOscar']; ctx._source['meta']['actors'] = params['meta']['actors']; ctx._source['meta']['extra']['rating'] = params['meta']['extra']['rating'];`,
     });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,6 +51,45 @@ describe('#set', () => {
       },
     });
   });
+
+  it('should work with hyphens', () => {
+    const fieldsMap = {};
+
+    fieldsMap["first-name"] = "John";
+    fieldsMap["last-name"] = "Doe";
+
+    const result = m.setNotFlattened(fieldsMap);
+
+    expect(result).toEqual({
+      lang: 'painless',
+      source: `ctx._source['first-name'] = params['first-name']; ctx._source['last-name'] = params['last-name'];`,
+      params: {
+        'first-name': "John",
+        'last-name': "Doe",
+      },
+    });
+  });
+
+  it('should assert subobjects with safe mode', () => {
+    const fieldsMap = {};
+
+    fieldsMap["first-name"] = "John";
+    fieldsMap["last-name"] = "Doe";
+    fieldsMap["metadata"] = {
+      paying : true
+    };
+
+    const result = m.setNotFlattened(fieldsMap, true);
+
+    expect(result).toEqual({
+      lang: 'painless',
+      source: `ctx._source['first-name'] = params['first-name']; ctx._source['last-name'] = params['last-name'];`,
+      params: {
+        'first-name': "John",
+        'last-name': "Doe",
+      },
+    });
+  });
 });
 
 describe('#setNotFlattened', () => {
@@ -95,7 +134,7 @@ describe('#setNotFlattened', () => {
         name: 'titanic',
       },
       source:
-        'ctx._source.id = params.id; ctx._source.name = params.name; ctx._source.meta.year = params.meta.year; ctx._source.meta.hasOscar = params.meta.hasOscar; ctx._source.meta.actors = params.meta.actors; ctx._source.meta.extra.rating = params.meta.extra.rating;',
+        `ctx._source['id'] = params['id']; ctx._source['name'] = params['name']; ctx._source['meta']['year'] = params['meta']['year']; ctx._source['meta']['hasOscar'] = params['meta']['hasOscar']; ctx._source['meta']['actors'] = params['meta']['actors']; ctx._source['meta']['extra']['rating'] = params['meta']['extra']['rating'];`,
     });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,22 +71,25 @@ describe('#set', () => {
   });
 
   it('should assert subobjects with safe mode', () => {
-    const fieldsMap = {};
-
-    fieldsMap["first-name"] = "John";
-    fieldsMap["last-name"] = "Doe";
-    fieldsMap["metadata"] = {
-      paying : true
+    const fieldsMap = {
+      'first-name': "John",
+      'last-name': "Doe",
+      metadata: {
+        paying: true
+      }
     };
 
     const result = m.setNotFlattened(fieldsMap, true);
 
     expect(result).toEqual({
       lang: 'painless',
-      source: `ctx._source['first-name'] = params['first-name']; ctx._source['last-name'] = params['last-name'];`,
+      source: `if (ctx._source['metadata'] == null) { ctx._source['metadata'] = [:] }ctx._source['first-name'] = params['first-name']; ctx._source['last-name'] = params['last-name']; ctx._source['metadata']['paying'] = params['metadata']['paying'];`,
       params: {
         'first-name': "John",
         'last-name': "Doe",
+        metadata: {
+          paying: true,
+        }
       },
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ type PainlessScript = {
 
 const BRACKET_NOTATION_REGEX = /\.\[/gm;
 const INLINE_SCRIPT_REGEX = /\n\s{1,}/g;
-const BRACKETS_SPLIT_REGEX = /\['[^\[\]]*'\]/gm
+const BRACKETS_SPLIT_REGEX = /\['[^[\]]*'\]/gm;
 
 const main = {
   set(fieldsMap: Record<string, unknown> = {}): PainlessScript {
@@ -26,21 +26,19 @@ const main = {
   setNotFlattened(fieldsMap: Record<string, unknown> = {}, safe?: boolean): PainlessScript {
     const flatFieldsMap: Record<string, unknown> = flatten(fieldsMap, {
       safe: true,
-      transformKey: key => (`['${key}']`)
+      transformKey: key => `['${key}']`,
     });
 
-    const brackets = Object.keys(flatFieldsMap)
-      .map(convertToBracketNotation);
+    const brackets = Object.keys(flatFieldsMap).map(convertToBracketNotation);
 
-    let prefix = "";
+    let prefix = '';
 
     if (safe) {
-      prefix = assertNullKeys(brackets)
+      prefix = assertNullKeys(brackets);
     }
 
-    const source = prefix + brackets
-      .map(bracket => `ctx._source${bracket} = params${bracket};`)
-      .join(' ')
+    const source =
+      prefix + brackets.map(bracket => `ctx._source${bracket} = params${bracket};`).join(' ');
 
     return {
       lang: 'painless',
@@ -323,26 +321,26 @@ const main = {
   },
 };
 
-function assertNullKeys(brackets: list<string>) : string {
-  let result = "";
+function assertNullKeys(brackets: list<string>): string {
+  let result = '';
 
   brackets.forEach(bracket => {
-    let match = bracket.match(BRACKETS_SPLIT_REGEX)
-    let assertKey = ``
+    const match = bracket.match(BRACKETS_SPLIT_REGEX);
+    let assertKey = ``;
 
     for (let i = 0; i < match.length - 1; i++) {
-      let currentMatch = match[i]
+      const currentMatch = match[i];
 
-      assertKey += currentMatch
+      assertKey += currentMatch;
 
       result += `if (ctx._source${assertKey} == null) {
         ctx._source${assertKey} = [:]
       }
-      `
+      `;
     }
-  })
+  });
 
-  return convertMultilineScriptToInline(result)
+  return convertMultilineScriptToInline(result);
 }
 
 function convertMultilineScriptToInline(script: string): string {
@@ -350,7 +348,7 @@ function convertMultilineScriptToInline(script: string): string {
 }
 
 function convertToBracketNotation(key: string): string {
-  return key.replace(BRACKET_NOTATION_REGEX, "[");
+  return key.replace(BRACKET_NOTATION_REGEX, '[');
 }
 
 export default main;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,8 @@ const main = {
 
           assertKey += currentMatch
 
-          prefix += `if (!ctx._source${assertKey}) {
-            ctx._source${assertKey} = {}
+          prefix += `if (ctx._source${assertKey} == null) {
+            ctx._source${assertKey} = [:]
           }
           `
         }


### PR DESCRIPTION
Hey there!

I just made a change by adding a safe mode solving two major problems:

1. Flattening using a.b.c is fine but can break in some cases. for instance, if doing `a.first-name` or `a.(first.name)`. In such cases, we shall use object bracket accessors instead by doing `a["first-name"] or `a["first.name"]`
2. There is no check for null pointers. So let's say we want to access to `a.metadata.read` where `a.metadata` is `null`, elasticsearch will reject updates. So I created a script prefix where we recursively initialize null values to empty objects