### PR TITLE
INT-11 Configure strict npmrc rules

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
 package-lock=false
 node-linker=hoisted
 lockfile=true
+trust-policy=no-downgrade
+block-exotic-subdeps=true
+minimum-release-age=20160
+ignore-scripts=true
+minimum-release-age-exclude[]=@shelf/*


### PR DESCRIPTION
This PR configures stricter pnpm install rules in `.npmrc`.

Why this is added:
- reduce the risk of dependency downgrades and unexpected subdependency resolution
- avoid pulling in very recent package releases before they have had time to settle
- keep `@shelf/*` packages exempt from the release-age gate
- disable install scripts for safer, more predictable installs

Applied settings:
- trust-policy=no-downgrade
- block-exotic-subdeps=true
- minimum-release-age=20160
- minimum-release-age-exclude[]=@shelf/*
- ignore-scripts=true

This PR also runs `pnpm install --no-frozen-lockfile` and commits any resulting lockfile updates.