### PR TITLE
OPS-6617 Resolve undici vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "overrides": {
       "js-yaml": "4.1.1",
       "strip-ansi": "6.0.1",
-      "undici": "6.23.0",
+      "undici": "6.24.0",
       "wrap-ansi": "7.0.0",
       "string-width": "4.2.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: 4.1.1
+  strip-ansi: 6.0.1
+  undici: 6.24.0
+  wrap-ansi: 7.0.0
+  string-width: 4.2.3
+
 importers:
 
   .:
@@ -3306,8 +3313,8 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+  undici@6.24.0:
+    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
     engines: {node: '>=18.17'}
 
   unrs-resolver@1.11.1:
@@ -3641,7 +3648,7 @@ snapshots:
       ms: 2.1.3
       secure-json-parse: 3.0.2
       tslib: 2.8.1
-      undici: 6.23.0
+      undici: 6.24.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7299,7 +7306,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  undici@6.23.0: {}
+  undici@6.24.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Updates the existing pnpm undici override from 6.23.0 to the patched 6.24.0 release.
- Refreshes pnpm-lock.yaml so transitive undici resolutions use 6.24.0.

## Vulnerability
- Addresses GHSA-v9p9-hfj2-hcw8 / OPS-6617: undici WebSocket client can throw an unhandled exception when validating an invalid server_max_window_bits value from the permessage-deflate extension, creating a denial-of-service crash risk.
- GitHub Dependabot alert #17 was verified open before the fix.
- Patched version: undici 6.24.0 for the affected <6.24.0 range.

## Validation
- pnpm install
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm type-check
- pnpm test