### PR TITLE
Pin pnpm 11 in es-painless-fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,6 @@
     "*.{ts,js}": [
       "eslint --fix"
     ]
-  }
+  },
+  "packageManager": "pnpm@11.18.0"
 }


### PR DESCRIPTION
## What
Add the `packageManager` field with `pnpm@11.18.0` to `package.json`.

## Why
We standardize all our repositories on pnpm 11. A pinned `packageManager` gives every developer and CI run the same pnpm version.

## How
- One small change in `package.json`.
- pnpm 11 keeps lockfile version `9.0`, so `pnpm-lock.yaml` stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
